### PR TITLE
Pin version of azure-devops-extension-api

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     }
   },
   "dependencies": {
-    "azure-devops-extension-api": "^1.152.0",
+    "azure-devops-extension-api": "1.153.2",
     "azure-devops-extension-sdk": "^2.0.7",
     "azure-devops-ui": "^1.152.2",
     "react": "^16.8.6",


### PR DESCRIPTION
This pull request resolves issue #3 by pinning the version of the azure-devops-extension-api.