### PR TITLE
Downgrade API version to `1.157.0` to support server versions specified in the manifest 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
       "name": "pipeline-approval",
       "license": "SEE LICENSE IN license.txt",
       "dependencies": {
-        "azure-devops-extension-api": "^4.266.0",
+        "azure-devops-extension-api": "1.157.0",
         "azure-devops-extension-sdk": "^4.2.0",
         "azure-devops-ui": "^2.268.0",
         "linq": "^4.0.3",
@@ -2407,15 +2407,23 @@
       }
     },
     "node_modules/azure-devops-extension-api": {
-      "version": "4.266.0",
-      "resolved": "https://registry.npmjs.org/azure-devops-extension-api/-/azure-devops-extension-api-4.266.0.tgz",
-      "integrity": "sha512-2T3KswiNCVaPMHgCeg23qRI5tS6AAII+ttQqbYaBo51CgEM8lvSLvM34UKWLbc7KdP2jGwtI2LjExMTru8NqgQ==",
+      "version": "1.157.0",
+      "resolved": "https://registry.npmjs.org/azure-devops-extension-api/-/azure-devops-extension-api-1.157.0.tgz",
+      "integrity": "sha512-CCN39A2VaRdi7MCeFWqhcv6dXOfSAf7W2jv1QWX1Hd9ac3n5PzguEPy+66SiPz5M+nDyMSP6aDTtwjEUX9D1kg==",
       "license": "MIT",
       "dependencies": {
+        "azure-devops-extension-sdk": "~2.0.11",
         "whatwg-fetch": "~3.0.0"
-      },
-      "peerDependencies": {
-        "azure-devops-extension-sdk": "^2 || ^3 || ^4"
+      }
+    },
+    "node_modules/azure-devops-extension-api/node_modules/azure-devops-extension-sdk": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/azure-devops-extension-sdk/-/azure-devops-extension-sdk-2.0.11.tgz",
+      "integrity": "sha512-9Hv4IeKpXR7EbaQn75Qz78rp0nv88XzRTF20E2oHlEFc+TRerekQnJjdrTHChoVvPvsWL/NAEwlqINU60U7neg==",
+      "license": "MIT",
+      "dependencies": {
+        "es6-object-assign": "^1.1.0",
+        "es6-promise": "^4.2.5"
       }
     },
     "node_modules/azure-devops-extension-sdk": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     }
   },
   "dependencies": {
-    "azure-devops-extension-api": "^4.266.0",
+    "azure-devops-extension-api": "1.157.0",
     "azure-devops-extension-sdk": "^4.2.0",
     "azure-devops-ui": "^2.268.0",
     "linq": "^4.0.3",

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -1,6 +1,6 @@
 {
   "manifestVersion": 1,
-  "version": "1.0.0",
+  "version": "1.3.2",
   "name": "Releases Approval Dashboard",
   "description": "A simple way for view and approve releases",
   "publisher": "gustavobergamim",


### PR DESCRIPTION
Downgrade API version to `1.157.0` to support server versions specified in the manifest config: `demands: [ "api-version/5.1" ]`