### PR TITLE
Update CI schedule to ignore unused develop branch

### DIFF
--- a/azure-pipelines-ci.yml
+++ b/azure-pipelines-ci.yml
@@ -15,11 +15,6 @@ pr:
     - develop
 
 schedules:
-- cron: "0 0 * * *"
-  displayName: Daily midnight build
-  branches:
-    include:
-    - develop
 - cron: "0 12 * * 0"
   displayName: Weekly Sunday build
   branches:


### PR DESCRIPTION
Removed daily midnight build schedule and updated to weekly Sunday build.