### PR TITLE
Refactor webpack config for asset handling

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,8 +13,7 @@ module.exports = {
   target: "web",
   entry: entries,
   output: {
-    filename: "[name]/[name].js",
-    publicPath: "/dist/"
+    filename: "[name]/[name].js"
   },
   devtool: "inline-source-map",
   devServer: {
@@ -52,12 +51,9 @@ module.exports = {
         use: ["style-loader", "css-loader"]
       },
       {
-        test: /\.woff$/,
-        use: [
-          {
-            loader: "base64-inline-loader"
-          }
-        ]
+        test: /\.woff2?$/i,
+        type: "asset/resource",
+        dependency: { not: ["url"] }
       },
       {
         test: /\.html$/,


### PR DESCRIPTION
Fix icon font loading in Azure DevOps extension
Remove webpack publicPath: "/dist/" so font assets resolve relative to the extension CDN path
Replace base64-inline-loader for fonts with asset/resource to avoid corrupt font data